### PR TITLE
Fix bug when default git branch name is not master

### DIFF
--- a/cli-implementation.js
+++ b/cli-implementation.js
@@ -86,7 +86,7 @@ function PushToDokku(giturl, tempDir) {
 
   const remoteBranch = "dokku";
 
-  execTemp("git init");
+  execTemp("git init -b master");
   execTemp("git add .");
   execTemp('git commit -am "Deploy"');
   execTemp(`git remote add ${remoteBranch} ${giturl}`);


### PR DESCRIPTION
Many people configure their git to use other names, like `main` or `trunk` or `develop`, which breaks dokku-pages. This PR explicitly executes `git init -b master`